### PR TITLE
Connect securely to js-marker-clusterer on github.

### DIFF
--- a/SugarModules/modules/jjwg_Maps/views/view.map_markers.php
+++ b/SugarModules/modules/jjwg_Maps/views/view.map_markers.php
@@ -178,7 +178,8 @@ var markerClusterer = null;
 var markerClustererToggle = null;
 var clusterControlDiv = null;
 // Clusterer Images - Protocol Independent
-MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+//MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 // Drawing Controls
 var drawingManager = null;


### PR DESCRIPTION
The link to google-maps-utility-library-v3 markercluseterplus project on googlecode is a broken link.
Update to use new link to the migrated googlemaps/js-marker-clusterer project on github.